### PR TITLE
Support the Baysor Cpp implementation

### DIFF
--- a/sopa/segmentation/methods/_baysor.py
+++ b/sopa/segmentation/methods/_baysor.py
@@ -146,7 +146,7 @@ def _get_baysor_command(prior_shapes_key: str | None) -> str:
 
     prior_suffix = f" :{prior_shapes_key}" if prior_shapes_key else ""  # use a prior segmentation
 
-    return f"{baysor_executable_path} run {polygon_format} -c config.toml transcripts.csv" + prior_suffix
+    return f"{baysor_executable_path} run {polygon_format} -c config.toml transcripts.csv -o ." + prior_suffix
 
 
 def _use_polygons_format_argument(baysor_executable_path: str) -> bool:

--- a/sopa/segmentation/methods/utils.py
+++ b/sopa/segmentation/methods/utils.py
@@ -87,6 +87,38 @@ def resolve(
 
     log.info(f"Added sdata.tables['{SopaKeys.TABLE}'], and {len(geo_df)} cell boundaries to sdata['{key_added}']")
 
+def _read_baysor_loom(loom_file: Path, obs_names: str, var_names: str) -> AnnData:
+    """Read a Baysor loom into an `AnnData`.
+
+    looms written with a transposed `/matrix` (cells x genes instead of 
+    genes x cells, as the Baysor Cpp does) can still be read.
+    """
+    import loompy
+
+    with loompy.connect(str(loom_file), "r", validate=False) as ds:
+        matrix = ds[:, :]
+        gene_names = np.asarray(ds.ra[var_names]).astype(str)
+        col_attrs = {key: np.asarray(ds.ca[key]) for key in ds.ca.keys()}
+
+    n_genes, n_cells = len(gene_names), len(col_attrs[obs_names])
+
+    if matrix.shape == (n_genes, n_cells):
+        matrix = matrix.T
+    elif matrix.shape != (n_cells, n_genes):
+        raise ValueError(f"Unexpected loom matrix shape {matrix.shape} for {n_genes=}, {n_cells=}")
+
+    obs = pd.DataFrame(
+        {
+            key: val.astype(str) if val.dtype.kind in "SUO" else val
+            for key, val in col_attrs.items()
+            if key != obs_names
+        },
+        index=pd.Index(col_attrs[obs_names].astype(str)),
+    )
+    var = pd.DataFrame(index=pd.Index(gene_names))
+
+    return AnnData(X=np.ascontiguousarray(matrix, dtype=np.float32), obs=obs, var=var)
+
 
 def _read_one_segmented_patch(
     directory: str, min_area: float = 0, min_vertices: int = 4
@@ -96,7 +128,12 @@ def _read_one_segmented_patch(
 
     loom_file = directory / "segmentation_counts.loom"
     if loom_file.exists():
-        adata = anndata.io.read_loom(directory / "segmentation_counts.loom", obs_names="Name", var_names="Name")
+        try:
+            adata = anndata.io.read_loom(loom_file, obs_names="Name", var_names="Name")
+        except ValueError:
+            # Re-read transposed (cells x genes) matrix with loompy using
+            # `validate=False` and rebuild the AnnData with the right orientation.
+            adata = _read_baysor_loom(loom_file, obs_names="Name", var_names="Name")
     else:
         adata = anndata.io.read_h5ad(directory / "segmentation_counts.h5ad")
 

--- a/sopa/segmentation/methods/utils.py
+++ b/sopa/segmentation/methods/utils.py
@@ -96,27 +96,17 @@ def _read_baysor_loom(loom_file: Path, obs_names: str, var_names: str) -> AnnDat
     """
     import loompy
 
-    with loompy.connect(str(loom_file), "r", validate=False) as ds:
+    with loompy.connect(loom_file, "r", validate=False) as ds:
         matrix = ds[:, :]
-        gene_names = np.asarray(ds.ra[var_names]).astype(str)
-        col_attrs = {key: np.asarray(ds.ca[key]) for key in ds.ca}
+        var = pd.DataFrame(index=pd.Index(np.asarray(ds.ra[var_names])))
+        obs = pd.DataFrame({key: np.asarray(ds.ca[key]) for key in ds.ca})
+        obs = obs.set_index(obs_names)
 
-    n_genes, n_cells = len(gene_names), len(col_attrs[obs_names])
-
-    if matrix.shape == (n_genes, n_cells):
+    # Baysor Cpp writes a transposed (genes x cells) matrix; orient it to cells x genes
+    if matrix.shape == (var.shape[0], obs.shape[0]):
         matrix = matrix.T
-    elif matrix.shape != (n_cells, n_genes):
-        raise ValueError(f"Unexpected loom matrix shape {matrix.shape} for {n_genes=}, {n_cells=}")
-
-    obs = pd.DataFrame(
-        {
-            key: val.astype(str) if val.dtype.kind in "SUO" else val
-            for key, val in col_attrs.items()
-            if key != obs_names
-        },
-        index=pd.Index(col_attrs[obs_names].astype(str)),
-    )
-    var = pd.DataFrame(index=pd.Index(gene_names))
+    elif matrix.shape != (obs.shape[0], var.shape[0]):
+        raise ValueError(f"Unexpected loom matrix shape {matrix.shape} for {var.shape[0]=}, {obs.shape[0]=}")
 
     return AnnData(X=np.ascontiguousarray(matrix, dtype=np.float32), obs=obs, var=var)
 

--- a/sopa/segmentation/methods/utils.py
+++ b/sopa/segmentation/methods/utils.py
@@ -88,29 +88,6 @@ def resolve(
     log.info(f"Added sdata.tables['{SopaKeys.TABLE}'], and {len(geo_df)} cell boundaries to sdata['{key_added}']")
 
 
-def _read_baysor_loom(loom_file: Path, obs_names: str, var_names: str) -> AnnData:
-    """Read a Baysor loom into an `AnnData`.
-
-    looms written with a transposed `/matrix` (cells x genes instead of
-    genes x cells, as the Baysor Cpp does) can still be read.
-    """
-    import loompy
-
-    with loompy.connect(loom_file, "r", validate=False) as ds:
-        matrix = ds[:, :]
-        var = pd.DataFrame(index=pd.Index(np.asarray(ds.ra[var_names])))
-        obs = pd.DataFrame({key: np.asarray(ds.ca[key]) for key in ds.ca})
-        obs = obs.set_index(obs_names)
-
-    # Baysor Cpp writes a transposed (genes x cells) matrix; orient it to cells x genes
-    if matrix.shape == (var.shape[0], obs.shape[0]):
-        matrix = matrix.T
-    elif matrix.shape != (obs.shape[0], var.shape[0]):
-        raise ValueError(f"Unexpected loom matrix shape {matrix.shape} for {var.shape[0]=}, {obs.shape[0]=}")
-
-    return AnnData(X=np.ascontiguousarray(matrix, dtype=np.float32), obs=obs, var=var)
-
-
 def _read_one_segmented_patch(
     directory: str, min_area: float = 0, min_vertices: int = 4
 ) -> tuple[list[Polygon], AnnData]:
@@ -119,12 +96,7 @@ def _read_one_segmented_patch(
 
     loom_file = directory / "segmentation_counts.loom"
     if loom_file.exists():
-        try:
-            adata = anndata.io.read_loom(loom_file, obs_names="Name", var_names="Name")
-        except ValueError:
-            # Re-read transposed (cells x genes) matrix with loompy using
-            # `validate=False` and rebuild the AnnData with the right orientation.
-            adata = _read_baysor_loom(loom_file, obs_names="Name", var_names="Name")
+        adata = anndata.io.read_loom(directory / "segmentation_counts.loom", obs_names="Name", var_names="Name")
     else:
         adata = anndata.io.read_h5ad(directory / "segmentation_counts.h5ad")
 

--- a/sopa/segmentation/methods/utils.py
+++ b/sopa/segmentation/methods/utils.py
@@ -87,10 +87,11 @@ def resolve(
 
     log.info(f"Added sdata.tables['{SopaKeys.TABLE}'], and {len(geo_df)} cell boundaries to sdata['{key_added}']")
 
+
 def _read_baysor_loom(loom_file: Path, obs_names: str, var_names: str) -> AnnData:
     """Read a Baysor loom into an `AnnData`.
 
-    looms written with a transposed `/matrix` (cells x genes instead of 
+    looms written with a transposed `/matrix` (cells x genes instead of
     genes x cells, as the Baysor Cpp does) can still be read.
     """
     import loompy
@@ -98,7 +99,7 @@ def _read_baysor_loom(loom_file: Path, obs_names: str, var_names: str) -> AnnDat
     with loompy.connect(str(loom_file), "r", validate=False) as ds:
         matrix = ds[:, :]
         gene_names = np.asarray(ds.ra[var_names]).astype(str)
-        col_attrs = {key: np.asarray(ds.ca[key]) for key in ds.ca.keys()}
+        col_attrs = {key: np.asarray(ds.ca[key]) for key in ds.ca}
 
     n_genes, n_cells = len(gene_names), len(col_attrs[obs_names])
 


### PR DESCRIPTION
This PR adds support for Baysor C++ v0.8.2 (issue #427).

### What changed

- Added `-o .` to the Baysor command so the outputs are written directly into the patch directory instead of a `segmentation.csv/ `subfolder.

### Reverted changes

- Re-read `segmentation_counts.loom `with loompy using `validate=False` and rebuild the `AnnData` with the correct orientation. The Baysor C++ implementation writes the matrix transposed (cells × genes) relative to the Loom spec (genes × cells), which makes `read_loom` reject the file.

Loom is not well maintained and supports only a subset of anndata features. The `anndata.io.read_loom `reader is also deprecated since anndata 0.13 (see https://anndata.readthedocs.io/en/latest/generated/anndata.io.read_loom.html). Switching the Baysor command to TSV output might be the better long-term option.

@quentinblampey
 
Closes #427 